### PR TITLE
add section about implementing extensions

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,62 @@ See the current set of [adopted extensions](https://ocfl.github.io/extensions/) 
 
 To use OCFL extensions you first need an OCFL client that supports the desired extensions. OCFL clients are not required to support extensions to be compliant with the OCFL specification, and the extensions that any given client supports will vary. The idea behind this repository is to encourage the development and implementation of common extensions so that there can be interoperability between OCFL clients.
 
+## Implementing Community Extensions
+
+Reference the spec's description of [object extensions](https://ocfl.io/1.0/spec/#object-extensions) and [storage root extensions](https://ocfl.io/1.0/spec/#storage-root-extensions).
+
+A *root extension directory* refers to the directory named `extensions` that is located in either the storage root or an object root. An *extension directory* is an extension specific directory that is the child of a root extension directory and named using the extension's *Registered Name*. For example, `extensions/0000-example-extension` is the extension directory for the extension [0000-example-extension](docs/0000-example-extension.md).
+
+Each extension specification details how it should be implemented, but there are a few rules that apply to every extension.
+
+The OCFL storage root MAY contain a copy of an extension's specification.
+
+### Manifest
+
+Every extension that is intended to be used MUST be declared in an extension manifest file. The extension manifest file is a JSON file named `extensions.json` that is a child of a root extension directory. This file MUST contain a JSON object with a single key, `extensions`, thats value is an array of registered extension names.
+
+For example, using the extension [0000-example-extension](docs/0000-example-extension.md) in an object, necessitates creating a manifest file at `OBJECT_ROOT/extensions/extensions.json` that contains the following:
+
+```json
+{
+  "extensions": [
+    "0000-example-extension"
+  ]
+}
+```
+
+Storage layout extensions MUST NOT be declared in the manifest. They are instead declared in `ocfl_layout.json`, as described in the [OCFL spec](https://ocfl.io/1.0/spec/#root-structure).
+
+It is permissible for a root extension directory to contain extension directories for extensions that are not declared in the extension manifest. Extensions that are not declared MUST NOT be used.
+
+When accessing a repository or object, the extension manifest SHOULD be read and the declared extensions loaded before interacting with any objects or object content.
+
+### Parameter Files
+
+Extension parameters are serialized as a JSON object and written to a file that is named for its *Registered Name* with a `.json` extension. If the extension is a storage layout extension and referenced in `ocfl_layout.json`, then the parameter file, if it has one, MUST be written to the storage root. Otherwise, it MUST be written to the extension's extension directory.
+
+For example, the extension [0000-example-extension](docs/0000-example-extension.md) could be parameterized as follows:
+
+```json
+{ 
+  "firstExampleParameter": 12, 
+  "secondExampleParameter": "Hello", 
+  "thirdExampleParameter": "Green" 
+}
+```
+
+Based how the extension is used, its parameter file is written to one of the following locations, relative the storage root:
+
+* `0000-example-extension.json`, if it is a storage layout extension
+* `extensions/0000-example-extension/0000-example-extension.json`, if it is a [storage root extension](https://ocfl.io/1.0/spec/#storage-root-extensions)
+* `OBJECT_ROOT/extensions/0000-example-extension/0000-example-extension.json`, if it is an [object extension](https://ocfl.io/1.0/spec/#object-extensions)
+
+### Undefined Behavior
+
+It is conceivable that some extensions may not be compatible with other extensions, or may be rendered incompatible based on how they're implemented in a client. For example, suppose that there are multiple extensions that define how logs should be written to an object's log directory. You could declare that your objects are using multiple log extensions, but the result is undefined and up to the implementing client. It may only write one log format or the other, it may write all of them, or it may reject the configuration entirely.
+
+Because OCFL clients are not required to implement any or all extensions, it is also possible that a client may encounter an extension that it does not implement. In these cases, it is up to the client to decide how to proceed. A client may fail on unsupported extensions, or it may choose to ignore the extensions and carry on.
+
 ## Specifying Community Extensions
 
 ### Layout

--- a/README.md
+++ b/README.md
@@ -20,29 +20,9 @@ Each extension specification details how it should be implemented, but there are
 
 The OCFL storage root MAY contain a copy of an extension's specification.
 
-### Manifest
-
-Every extension that is intended to be used MUST be declared in an extension manifest file. The extension manifest file is a JSON file named `extensions.json` that is a child of a root extension directory. This file MUST contain a JSON object with a single key, `extensions`, thats value is an array of registered extension names.
-
-For example, using the extension [0000-example-extension](docs/0000-example-extension.md) in an object, necessitates creating a manifest file at `OBJECT_ROOT/extensions/extensions.json` that contains the following:
-
-```json
-{
-  "extensions": [
-    "0000-example-extension"
-  ]
-}
-```
-
-Storage layout extensions MUST NOT be declared in the manifest. They are instead declared in `ocfl_layout.json`, as described in the [OCFL spec](https://ocfl.io/1.0/spec/#root-structure).
-
-A root extension directory MAY contain extension directories for extensions that are not declared in the extension manifest. Extensions that are not declared MUST NOT be used.
-
-When accessing a repository or object, the extension manifest SHOULD be read and the declared extensions loaded before interacting with any objects or object content. At this time, any configurations files that exist for the declared extensions should also be loaded.
-
 ### Configuration Files
 
-Extension parameters are serialized as JSON objects and written to configuration files that are named using the extension's *Registered Name* with a `.json` extension. If the extension is a storage layout extension and referenced in `ocfl_layout.json`, then the configuration file, if it has one, MUST be written to the storage root. Otherwise, it MUST be written to the extension's extension directory.
+Extension parameters are serialized as JSON objects and written to configuration files named `config.json` within the extension's extension directory.
 
 For example, the extension [0000-example-extension](docs/0000-example-extension.md) could be parameterized as follows:
 
@@ -56,9 +36,8 @@ For example, the extension [0000-example-extension](docs/0000-example-extension.
 
 Based on how the extension is used, its configuration file is written to one of the following locations, relative the storage root:
 
-* `0000-example-extension.json`, if it is a storage layout extension
-* `extensions/0000-example-extension/0000-example-extension.json`, if it is a [storage root extension](https://ocfl.io/1.0/spec/#storage-root-extensions)
-* `OBJECT_ROOT/extensions/0000-example-extension/0000-example-extension.json`, if it is an [object extension](https://ocfl.io/1.0/spec/#object-extensions)
+* `extensions/0000-example-extension/config.json`, if it is a [storage root extension](https://ocfl.io/1.0/spec/#storage-root-extensions)
+* `OBJECT_ROOT/extensions/0000-example-extension/config.json`, if it is an [object extension](https://ocfl.io/1.0/spec/#object-extensions)
 
 ### Undefined Behavior
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ To use OCFL extensions you first need an OCFL client that supports the desired e
 
 ## Implementing Community Extensions
 
-Reference the spec's description of [object extensions](https://ocfl.io/1.0/spec/#object-extensions) and [storage root extensions](https://ocfl.io/1.0/spec/#storage-root-extensions).
+Reference the OCFL specifications's description of [object extensions](https://ocfl.io/1.0/spec/#object-extensions) and [storage root extensions](https://ocfl.io/1.0/spec/#storage-root-extensions).
 
 A *root extension directory* refers to the directory named `extensions` that is located in either the storage root or an object root. An *extension directory* is an extension specific directory that is the child of a root extension directory and named using the extension's *Registered Name*. For example, `extensions/0000-example-extension` is the extension directory for the extension [0000-example-extension](docs/0000-example-extension.md).
 
@@ -36,7 +36,7 @@ For example, using the extension [0000-example-extension](docs/0000-example-exte
 
 Storage layout extensions MUST NOT be declared in the manifest. They are instead declared in `ocfl_layout.json`, as described in the [OCFL spec](https://ocfl.io/1.0/spec/#root-structure).
 
-It is permissible for a root extension directory to contain extension directories for extensions that are not declared in the extension manifest. Extensions that are not declared MUST NOT be used.
+A root extension directory MAY contain extension directories for extensions that are not declared in the extension manifest. Extensions that are not declared MUST NOT be used.
 
 When accessing a repository or object, the extension manifest SHOULD be read and the declared extensions loaded before interacting with any objects or object content. At this time, any configurations files that exist for the declared extensions should also be loaded.
 
@@ -54,7 +54,7 @@ For example, the extension [0000-example-extension](docs/0000-example-extension.
 }
 ```
 
-Based how the extension is used, its configuration file is written to one of the following locations, relative the storage root:
+Based on how the extension is used, its configuration file is written to one of the following locations, relative the storage root:
 
 * `0000-example-extension.json`, if it is a storage layout extension
 * `extensions/0000-example-extension/0000-example-extension.json`, if it is a [storage root extension](https://ocfl.io/1.0/spec/#storage-root-extensions)

--- a/README.md
+++ b/README.md
@@ -38,11 +38,11 @@ Storage layout extensions MUST NOT be declared in the manifest. They are instead
 
 It is permissible for a root extension directory to contain extension directories for extensions that are not declared in the extension manifest. Extensions that are not declared MUST NOT be used.
 
-When accessing a repository or object, the extension manifest SHOULD be read and the declared extensions loaded before interacting with any objects or object content.
+When accessing a repository or object, the extension manifest SHOULD be read and the declared extensions loaded before interacting with any objects or object content. At this time, any configurations files that exist for the declared extensions should also be loaded.
 
-### Parameter Files
+### Configuration Files
 
-Extension parameters are serialized as a JSON object and written to a file that is named for its *Registered Name* with a `.json` extension. If the extension is a storage layout extension and referenced in `ocfl_layout.json`, then the parameter file, if it has one, MUST be written to the storage root. Otherwise, it MUST be written to the extension's extension directory.
+Extension parameters are serialized as JSON objects and written to configuration files that are named using the extension's *Registered Name* with a `.json` extension. If the extension is a storage layout extension and referenced in `ocfl_layout.json`, then the configuration file, if it has one, MUST be written to the storage root. Otherwise, it MUST be written to the extension's extension directory.
 
 For example, the extension [0000-example-extension](docs/0000-example-extension.md) could be parameterized as follows:
 
@@ -54,7 +54,7 @@ For example, the extension [0000-example-extension](docs/0000-example-extension.
 }
 ```
 
-Based how the extension is used, its parameter file is written to one of the following locations, relative the storage root:
+Based how the extension is used, its configuration file is written to one of the following locations, relative the storage root:
 
 * `0000-example-extension.json`, if it is a storage layout extension
 * `extensions/0000-example-extension/0000-example-extension.json`, if it is a [storage root extension](https://ocfl.io/1.0/spec/#storage-root-extensions)

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ The OCFL storage root MAY contain a copy of an extension's specification.
 
 ### Configuration Files
 
-Extension parameters are serialized as JSON objects and written to configuration files named `config.json` within the extension's extension directory.
+An extension's parameters are serialized as a JSON object and written to a configuration file named `config.json` within the extension's extension directory.
 
 For example, the extension [0000-example-extension](docs/0000-example-extension.md) could be parameterized as follows:
 


### PR DESCRIPTION
This is the second breakout from PR #29. It covers how extensions should be implemented.

It includes additional, and perhaps controversial, changes from the same section in PR #29. Specifically, it introduces a new extension manifest file, `extensions.json` that is located in root extension directories. Per the OCFL spec, it is technically not permissible to have this file in the root extension directory. I think this is a mistake, but a workaround could be to stick it in a subdirectory instead.

Why is the manifest needed? Having the manifest explicitly declare what extensions are in use enables extension chaining extensions and gracefully handles obsoleted extensions or extensions that are no longer used.

In the chaining case, suppose that you have an extension that chains together 3 other extensions. The chaining extension and each of the chained extensions each have their own configuration. So, you have a root extension directory that looks something like this:

```
extensions/
  - 0001-extension-a /
  - 0002-extension-b/
  - 0003-extension-c/
  - 0004-extension-d/
```

Without the manifest, a client has to inspect the `extensions` directory and load whatever it finds. The end result in this case is that 4 unique extensions are loaded.

If it had a manifest that looked like:

```json
{
  "extensions": [
    "0004-extension-d"
  ]
}
```

Then, it would instead only load a single extension, the chaining extension, which would in turn load its dependent extensions. It is true, this same behavior could be achieved without the manifest but it is more convoluted and requires a second pass to "link" the dependent extensions after the initial load.

In the obsoleted/deprecated case, suppose that you're using an extension and decide to replace it with another or stop using it entirely. In this case, you do not necessarily want to get rid of the extension's configuration. For example, let's say that it's an extension that describes a log format that you're no longer using, but you still have historic files in the log directory that use the format. You probably want to keep a record of the extension that created those files and its configuration, and you can do so if you can have extension configuration within the `extensions` directory that is not actively used because it is not declared as being in use.

Finally, there is an outstanding problem that this PR still does not address, which is how can you used the same extension configured in multiple different ways on the same repository or object? For example, let's say that there's an extension that's used for specifying id formats, and you have a repository that contains two distinct types of ids. It is currently impossible to use the same extension to define both of the formats, assuming that the extension itself does not internally support this, because the extension can only be configured once.