### PR TITLE
update extension spec spec

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,61 +6,45 @@ The current set of extensions can be read on [GitHub Pages](https://ocfl.github.
 
 See also [pending pull requests](https://github.com/OCFL/extensions/pulls) for extensions under discussion.
 
-## Organization of this repository
+## Specifying Community Extensions
 
-Community extensions should be written as GitHub flavored markdown files in the `docs` directory of this repository. The
+### Layout
+
+Community extensions MUST be written as GitHub flavored markdown files in the `docs` directory of this repository. The
 filename of an extension is based on its *Registered Name* with a `.md` extension. 
 
 Extensions are numbered sequentially, and the *Registered Name* of an extension is prefixed with this 4-digit, zero-padded
-decimal number. The *Registered Name* should be descriptive, use hyphens to separate words and have a maximum of 250 
-characters in total. New, or substantially revised, extensions MUST use the next available number based on extensions current
-at the time of merging. The *Registered Name* MUST be listed in the header of the extension file. 
+decimal number. The *Registered Name* should be descriptive, use hyphens to separate words, and have a maximum of 250
+characters in total. New extensions MUST use the next available prefix number that's available at the time of merging.
 
-An example/template is available in this repository as [OCFL Community Extension](docs/0000-example-extension.md) and is rendered
+Extensions are intended to be mostly static once published. Substantial revisions of content beyond simple fixes warrants publishing a new extension, and marking the old extension obsolete by updating the *Obsoletes/Obsoleted by* sections in each extension respectively.
+
+An example/template is available [here](docs/0000-example-extension.md) and is rendered
 via GitHub pages as https://ocfl.github.io/extensions/0000-example-extension
 
-## Extension Parameters
+### Headers
 
-For efficiency, it is likely that many extension definitions might actually cover a number of variants. Therefore, when an
-extension is referenced, it MAY be accompanied by a number of parameters that specify the particular variant in use. This
-provides both more effective documentation of an OCFL structure and allows the implementation of generic extension code that
-covers a wider variety of use cases. Parameters MUST be single valued. For each parameter the following properties should
-be defined:    
+Extensions MUST contain a header section that defines the following fields:
 
-* Name: A short name for the parameter. Since this has the potential to be used as part of programmatic access the name MUST
-comply with the Javascript restrictions on identifiers (The first character must be a letter, an underscore, or a dollar sign. 
-Subsequent characters may be letters, digits, underscores, or dollar signs.) and SHOULD be shorter than 127 characters. The
-length limit is based on a survey of the defaults for various JSON parsers. 
-* Description: A brief description of the function of the parameter. This should be expanded in the main description of the
-extension which MUST reference all the parameters.
-* Type: Data type for the parameter. In order to allow validation and limit the scope for implementation specific variations,
-parameters are typed.
-  * integer - may be signed or not as specified in the range property.
-  * string - aligned with JSON strings, these should be UTF-8 encoded and avoid control characters.  
-  * enumerated - one of an ordered set of labels which MUST conform to the same limitations as parameter names.  
-  * boolean - MUST have the value *false* or *true* (lower case and unquoted as in JSON)
-* Range: Further qualifies the valid values for a parameter depending on its type.
-  * For integer parameters, the range specifies minimum and maximum values, separated by a comma, which MUST be integers themselves.
-  * For string parameters, the range specifies the maximum length of the string as an integer number of characters, not bytes. Again, based on a survey of parsers, strings SHOULD be shorter than 4095 characters.
-  * For enumerated parameters, the range is a comma separated ordered list of labels that are valid for the parameter. Enumerated parameters are case sensitive and MUST always be quoted, so they are JSON strings. 
-* Default: Default value for parameter, which MUST be consistent with the range limitations. If this is left blank then the parameter is mandatory (if parameters are defined)  
+* **Extension Name**: The extension's unique *Registered Name*
+* **Authors**: The names of the individuals who authored the extension
+* **Minimum OCFL Version**: The minimum OCFL version that the extension requires, eg. *1.0*
+* **Obsoletes**: The *Registered Name* of the extension that this extension obsoletes, or *n/a*
+* **Obsoleted by**: The *Registered Name* of the extension that obsoletes this extension, or *n/a*
 
-## Referencing Parameters
+### Parameters
 
-Wherever a parameterised extension is referenced, any parameters MAY be included in an accompanying sidecar JSON file that
-uses the registered name with the filename extension `.json`. If using an 'extensions' directory, the JSON file MUST be 
-included in the root directory of the extension and not a subdirectory. Another place that an extension may be 
-referenced is `ocfl_layout.json` where the sidecar file should be alongside it in the Storage Root. 
+Extensions MAY define parameters to enable configuration as needed. Extension parameters are serialized as JSON values, and therefore must conform to the [JSON specification](https://tools.ietf.org/html/rfc8259). Parameters MUST be defined in the following structure:
 
-For example, the example extension above would have an accompanying file *0000-example-extension.json* which might contain:
+* **Name**: A short, descriptive name for the parameter. The name is used as the parameter's key within its JSON representation.
+   * **Description**: A brief description of the function of the parameter. This should be expanded on in the main description of the extension which MUST reference all the parameters.
+   * **Type**: The JSON data type of the parameter value. One of `string`, `number`, `boolean`, `array`, or `object`. The structure of complex types MUST be further described.
+   * **Constraints**: A description of any constraints to apply to parameter values. For example, "May not be empty", "Must be greater than 1 and less than 100", or "Must be one of 'red', 'blue', 'green'." 
+   * **Default**: The default value of parameter. If no default is specified, then the parameter is mandatory.
 
-    "0000-example-extension": {  
-        "firstExampleParameter": 12,  
-        "secondExampleParameter": "Hello",  
-        "thirdExampleParameter": "Green"  
-    }
-    
-An extension MAY be referenced without providing any parameters, even if they are defined for that extension. However, if parameters are defined they MUST be complete, with valid values specified for all parameters that do not have a default. There MUST only be one parameter set defined for each extension reference.
+### Body
+
+Each specification MUST thoroughly document how it is intended to be implemented and used, including detailed examples is helpful. If the extension uses parameters, the parameters MUST be described in detail in the body of the specification.
 
 ## Review / Merge Policy
 

--- a/docs/0000-example-extension.md
+++ b/docs/0000-example-extension.md
@@ -22,7 +22,7 @@ This extension is but an example and has no content, but if it did the content w
 * **Name:** secondExampleParameter
   * **Description:** An optional 64 character long string, defaulting to "Not applicable", if omitted.
   * **Type:** string
-  * **Constraints:** Must be 64 characters long
+  * **Constraints:** Must be less than or equal to 64 characters long
   * **Default:** "Not applicable"
 * **Name:** thirdExampleParameter
   * **Description:** An example enumerated parameter

--- a/docs/0000-example-extension.md
+++ b/docs/0000-example-extension.md
@@ -1,10 +1,10 @@
 # OCFL Community Extension 0000: Example Extension
 
-  * Extension Name: 0000-example-extension
-  * Authors: A Person, Other Person
-  * Minimum OCFL Version: 1.0
-  * Obsoletes: n/a
-  * Obsoleted by: n/a
+  * **Extension Name:** 0000-example-extension
+  * **Authors:** A Person, Other Person
+  * **Minimum OCFL Version:** 1.0
+  * **Obsoletes:** n/a
+  * **Obsoleted by:** n/a
 
 *Note: This is not a real extension, merely an example.*
 
@@ -14,21 +14,21 @@ This extension is but an example and has no content, but if it did the content w
 
 ## Parameters
 
-* name: firstExampleParameter
-  * description: a mandatory 8 bit unsigned value
-  * type: integer
-  * range: 0,255
-  * default:
-* name: secondExampleParameter
-  * description: an optional 64 character long string, defaulting to "Not applicable", if omitted.
-  * type: string
-  * range: 64
-  * default: "Not applicable"
-* name: thirdExampleParameter
-  * description: An example enumerated parameter
-  * type: enumerated
-  * range: "Red","Yellow","Orange","Green","Blue","Indigo","Violet"
-  * default: "Green"
+* **Name:** firstExampleParameter
+  * **Description:** A mandatory 8 bit unsigned value
+  * **Type:** number
+  * **Constraints:** Must be an integer between 0 and 255 inclusive
+  * **Default:**
+* **Name:** secondExampleParameter
+  * **Description:** An optional 64 character long string, defaulting to "Not applicable", if omitted.
+  * **Type:** string
+  * **Constraints:** Must be 64 characters long
+  * **Default:** "Not applicable"
+* **Name:** thirdExampleParameter
+  * **Description:** An example enumerated parameter
+  * **Type:** string
+  * **Constraints:** Must be one of the following: "Red","Yellow","Orange","Green","Blue","Indigo","Violet"
+  * **Default:** "Green"
 
 ## Other Sections Providing Details, Examples, etc.
 

--- a/docs/0001-digest-algorithms.md
+++ b/docs/0001-digest-algorithms.md
@@ -1,10 +1,10 @@
 # OCFL Community Extension 0001: Digest Algorithms
 
-  * Extension Name: 0001-digest-algorithms
-  * Authors: OCFL Editors
-  * Minimum OCFL Version: 1.0
-  * Obsoletes: n/a
-  * Obsoleted by: n/a
+  * **Extension Name:** 0001-digest-algorithms
+  * **Authors:** OCFL Editors
+  * **Minimum OCFL Version:** 1.0
+  * **Obsoletes:** n/a
+  * **Obsoleted by:** n/a
 
 ## Overview
 


### PR DESCRIPTION
This is the final breakout part of PR #29. It covers how extensions are specified. It standardizes a set of headers that must be included, and simplifies parameter definitions.