### PR TITLE
Add link from adopted extensions page to spec and ext repo

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -8,3 +8,5 @@
   * [0006: Flat Omit Prefix Storage Layout](0006-flat-omit-prefix-storage-layout.md)
   * [0007: N Tuple Omit Prefix Storage Layout](0007-n-tuple-omit-prefix-storage-layout.md)
   * [0008: Schema Registry](0008-schema-registry)
+
+The above extensions to the [OCFL Specification and Implementation Notes](https://ocfl.io/) have been reviewed and adopted by the OCFL Community. [Draft extensions under development and review](https://github.com/OCFL/extensions/pulls) are available in the [OCFL Extensions repository](https://github.com/OCFL/extensions).


### PR DESCRIPTION
Fixes https://github.com/OCFL/extensions/issues/60 . No change to extension content